### PR TITLE
제품상세, 장바구니, 마이페이지 홈/주문내역/취소내역

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,6 @@ const App = () => {
 
   return (
     <Routes>
-<<<<<<< HEAD
       <Route path="/" element={<MainPage products={products} setProducts={setProducts} />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignUpPage />} />
@@ -46,20 +45,6 @@ const App = () => {
       <Route path="/cart" element={<CartPage />} />
       <Route path="/order" element={<OrderPage />} />
       <Route path="/user/:menu" element={<UserPage />} />
-=======
-      <Route path="/" element={<Layout />}>
-        <Route index element={<MainPage products={products} setProducts={setProducts} />} />
-        <Route path="login" element={<LoginPage />} />
-        <Route path="signup" element={<SignUpPage />} />
-        <Route path="search" element={<SearchPage />} />
-        <Route path="category/:category/:brand" element={<CategoryPage products={categoryItems} />} />
-        <Route path="category/:category" element={<CategoryPage products={categoryItems} />} />
-        <Route path="product/:id" element={<ProductdetailsPage />} />
-        <Route path="cart" element={<CartPage />} />
-        <Route path="order" element={<OrderPage />} />
-        <Route path="user" element={<UserPage />} />
-      </Route>
->>>>>>> c482b417b6420b33de8389ad9a7ec626c0504b03
     </Routes>
   );
 };

--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ import { getAllProduct } from './utils/useAPI';
 const App = () => {
   const [products, setProducts] = useState([]);
   const [categoryItems, setCategoryItems] = useState([]);
-  const [cart, setCart] = useState([]);
 
   useEffect(() => {
     const getProducts = async () => {
@@ -34,7 +33,7 @@ const App = () => {
       <Route path="/category/:category" element={<CategoryPage products={categoryItems} />} />
       <Route path="/product/:id" element={<ProductdetailsPage />} />
       <Route path="/cart" element={<CartPage />} />
-      <Route path="/order" element={<OrderPage/>} />
+      <Route path="/order" element={<OrderPage />} />
       <Route path="/user" element={<UserPage />} />
     </Routes>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,7 @@ const App = () => {
       <Route path="/product/:id" element={<ProductdetailsPage />} />
       <Route path="/cart" element={<CartPage />} />
       <Route path="/order" element={<OrderPage />} />
-      <Route path="/user" element={<UserPage />} />
+      <Route path="/user/:menu" element={<UserPage />} />
     </Routes>
   );
 };

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -25,7 +25,7 @@ const Links = ({}) => {
   }, []);
   return (
     <Wrap>
-      <Link to={`/user`}>
+      <Link to={`/user/OrderHistory`}>
         <button>안녕하세요. {user.displayName}님</button>
       </Link>
     </Wrap>

--- a/src/components/Userpage/AuthPassword.js
+++ b/src/components/Userpage/AuthPassword.js
@@ -1,23 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
+import { signIn } from '../../utils/useAPI';
+import Account from './Account';
 
-const InputPassword = ({ user }) => {
-  const handleSubmit = () => {};
+const AuthPassword = ({ user }) => {
+  const navigate = useNavigate();
+  const { register, handleSubmit } = useForm();
+  const OnSubmit = async (data) => {
+    const user = await signIn(data);
+    console.log(user);
+    if (!user) {
+      alert('비밀번호가 일치하지 않습니다.');
+    } else {
+      //   navigate('/editMemberInfo/modify');
+    }
+  };
 
   return (
     <Container>
       <h3>비밀번호 재확인</h3>
       <p>회원님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번 확인해주세요.</p>
-      <form>
+      <form onSubmit={handleSubmit(OnSubmit)}>
         <div>
           <label htmlFor="userId">아이디</label>
-          <input type="text" value={user.email} disabled />
+          <input type="text" value={user.email} disabled {...register('email', { value: `${user.email}` })} />
         </div>
         <div>
           <label htmlFor="userId">비밀번호</label>
-          <input type="text" placeholder="현재 비밀번호를 입력해주세요." required />
+          <input
+            type="text"
+            placeholder="현재 비밀번호를 입력해주세요."
+            required
+            {...register('password', { required: 'true' }, { minLength: 8 })}
+          />
         </div>
-        <button type="submit">확인</button>
+        <input type="submit" className="inputSubmit" value="확인" />
       </form>
     </Container>
   );
@@ -66,10 +85,11 @@ const Container = styled.div`
     div label {
       margin-right: 60px;
       padding-top: 12px;
+      width: 60px;
       font-weight: 700;
     }
 
-    button {
+    .inputSubmit {
       display: block;
       width: 240px;
       height: 56px;
@@ -80,8 +100,9 @@ const Container = styled.div`
       border: 1px solid #000;
 
       text-align: center;
+      cursor: pointer;
     }
   }
 `;
 
-export default InputPassword;
+export default AuthPassword;

--- a/src/components/Userpage/AuthPassword.js
+++ b/src/components/Userpage/AuthPassword.js
@@ -14,7 +14,8 @@ const AuthPassword = ({ user }) => {
     if (!user) {
       alert('비밀번호가 일치하지 않습니다.');
     } else {
-      //   navigate('/editMemberInfo/modify');
+      console.log('완료');
+      navigate('/user/EditMemberInfo');
     }
   };
 

--- a/src/components/Userpage/AuthPassword.js
+++ b/src/components/Userpage/AuthPassword.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { signIn } from '../../utils/useAPI';
 import Account from './Account';
 
-const AuthPassword = ({ user, id }) => {
+const AuthPassword = ({ user }) => {
   const navigate = useNavigate();
   const { register, handleSubmit } = useForm();
   const OnSubmit = async (data) => {
@@ -14,8 +14,7 @@ const AuthPassword = ({ user, id }) => {
     if (!user) {
       alert('비밀번호가 일치하지 않습니다.');
     } else {
-      console.log(id.id);
-      navigate('/user/EditMemberInfo');
+      navigate('/user/Account');
     }
   };
 

--- a/src/components/Userpage/AuthPassword.js
+++ b/src/components/Userpage/AuthPassword.js
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import styled from 'styled-components';
 import { signIn } from '../../utils/useAPI';
-import Account from './Account';
 
 const AuthPassword = ({ user }) => {
   const navigate = useNavigate();

--- a/src/components/Userpage/AuthPassword.js
+++ b/src/components/Userpage/AuthPassword.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { signIn } from '../../utils/useAPI';
 import Account from './Account';
 
-const AuthPassword = ({ user }) => {
+const AuthPassword = ({ user, id }) => {
   const navigate = useNavigate();
   const { register, handleSubmit } = useForm();
   const OnSubmit = async (data) => {
@@ -14,7 +14,7 @@ const AuthPassword = ({ user }) => {
     if (!user) {
       alert('비밀번호가 일치하지 않습니다.');
     } else {
-      console.log('완료');
+      console.log(id.id);
       navigate('/user/EditMemberInfo');
     }
   };

--- a/src/components/Userpage/InputPassword.js
+++ b/src/components/Userpage/InputPassword.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const InputPassword = ({ user }) => {
+  const handleSubmit = () => {};
+
+  return (
+    <Container>
+      <h3>비밀번호 재확인</h3>
+      <p>회원님의 정보를 안전하게 보호하기 위해 비밀번호를 다시 한번 확인해주세요.</p>
+      <form>
+        <div>
+          <label htmlFor="userId">아이디</label>
+          <input type="text" value={user.email} disabled />
+        </div>
+        <div>
+          <label htmlFor="userId">비밀번호</label>
+          <input type="text" placeholder="현재 비밀번호를 입력해주세요." required />
+        </div>
+        <button type="submit">확인</button>
+      </form>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  padding-top: 30px;
+
+  h3 {
+    padding-bottom: 8px;
+    font-weight: 700;
+    font-size: 16px;
+  }
+
+  p {
+    padding-bottom: 20px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: rgb(102, 102, 102);
+  }
+
+  form {
+    display: flex;
+    flex-direction: column;
+    align-items: left;
+    gap: 20px;
+
+    padding: 40px 250px;
+
+    div {
+      display: flex;
+      justify-content: space-between;
+    }
+
+    div input {
+      width: 400px;
+      height: 46px;
+      padding: 0px 11px 1px 15px;
+      border-radius: 4px;
+      border: 1px solid rgb(221, 221, 221);
+      font-weight: 400;
+      line-height: 1.5;
+      color: rgb(51, 51, 51);
+    }
+
+    div label {
+      margin-right: 60px;
+      padding-top: 12px;
+      font-weight: 700;
+    }
+
+    button {
+      display: block;
+      width: 240px;
+      height: 56px;
+      margin: 0 auto;
+      margin-top: 30px;
+      padding: 0px 10px;
+      border-radius: 3px;
+      border: 1px solid #000;
+
+      text-align: center;
+    }
+  }
+`;
+
+export default InputPassword;

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -2,39 +2,53 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import reset from '../../css/reset-css.css';
 import styled from 'styled-components';
-import { orderedProducts, confirmProduct } from '../../utils/useAPI';
+import { orderedProducts, confirmProduct, refundProduct } from '../../utils/useAPI';
 
 const OrderHistory = () => {
   const [ordered, setOdered] = useState([]);
-  const [confirmed, setConfirmed] = useState('');
 
   useEffect(() => {
+    // 전체제품 거래내역 가져오기
     const getorderedProducts = async () => {
       const json = await orderedProducts();
       setOdered(json);
     };
     getorderedProducts();
-    console.log(ordered);
   }, []);
 
+  // 거래 확정
   const orderConfirm = async (detailId) => {
     let body = JSON.stringify({
       detailId: detailId,
     });
     const json = await confirmProduct(body);
-    setConfirmed(json);
+    return json;
   };
 
   const handelOrderConfirm = (detailId) => {
     orderConfirm(detailId);
   };
-  //
+
+  // 거래 취소
+  const orderCancle = async (detailId) => {
+    let body = JSON.stringify({
+      detailId: detailId,
+    });
+    const json = await refundProduct(body);
+    return json;
+  };
+
+  const handelOrderCancle = (detailId) => {
+    orderCancle(detailId);
+  };
+
+  const ddEl = document.querySelectorAll('dd');
 
   return (
     <Container>
       <ol>
         {ordered.map((list) => (
-          <li key={list.detailId}>
+          <li key={list.detailId} className="orderedList">
             <Title>
               <h4>{list.timePaid}</h4>
               <span>주문내역 상세보기 ></span>
@@ -62,17 +76,31 @@ const OrderHistory = () => {
                 </div>
               </ProductInfo>
               <CancleOk>
-                {list.done ? (
-                  <button type="button" className="confirmtrue">
-                    확정완료
-                  </button>
+                {list.done === false && list.isCanceled === false ? (
+                  <>
+                    <button type="button" onClick={() => handelOrderConfirm(list.detailId)}>
+                      구매 확정
+                    </button>
+                    <button type="button" onClick={() => handelOrderCancle(list.detailId)}>
+                      구매 취소
+                    </button>
+                  </>
+                ) : list.done ? (
+                  <>
+                    <button type="button" className="confirmtrue">
+                      확정완료
+                    </button>
+                  </>
+                ) : list.isCanceled ? (
+                  <>
+                    <button type="button" className="confirmtrue">
+                      취소완료
+                    </button>
+                    {console.log(ddEl)}
+                  </>
                 ) : (
-                  <button type="button" onClick={() => handelOrderConfirm(list.detailId)}>
-                    거래 확정
-                  </button>
+                  ''
                 )}
-
-                <button>거래 취소</button>
               </CancleOk>
             </Details>
           </li>
@@ -136,6 +164,10 @@ const CancleOk = styled.div`
 
   .confirmtrue {
     background-color: #eaeaea;
+  }
+
+  .cancle {
+    text-decoration: line-through;
   }
 `;
 

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -1,10 +1,75 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import reset from '../../css/reset-css.css';
 import styled from 'styled-components';
+import { transaction } from '../../utils/useAPI';
 
 const OrderHistory = () => {
-  return <Container>나의 주문내역 컴포넌트</Container>;
+  const [history, setHistory] = useState([]);
+  useEffect(() => {
+    const getTransaction = async () => {
+      const json = await transaction();
+      setHistory(json);
+    };
+    getTransaction();
+  }, []);
+  console.log(history);
+  return (
+    <Container>
+      <ol>
+        {history.map((list) => (
+          <li key={list.detailId}>
+            <div>{list.timePaid}</div>
+            <ProductInfo>
+              <img src={list.product.thumbnail} alt={`${list.product.title} 썸네일`} />
+              <div>
+                <dl>
+                  <dt>상품명</dt>
+                  <dd>
+                    [{list.product.tags[0]}]{list.product.title}
+                  </dd>
+                </dl>
+                <dl>
+                  <dt>주문번호</dt>
+                  <dd>{list.detailId}</dd>
+                </dl>
+                <dl>
+                  <dt>결제금액</dt>
+                  <dd>${list.product.price.toLocaleString()}</dd>
+                </dl>
+              </div>
+            </ProductInfo>
+          </li>
+        ))}
+      </ol>
+    </Container>
+  );
 };
 
-const Container = styled.div``;
+const Container = styled.div`
+  li + li {
+    margin-top: 30px;
+    border-top: 1px solid #000;
+  }
+`;
+
+const ProductInfo = styled.div`
+  display: flex;
+  gap: 30px;
+  margin-top: 30px;
+
+  img {
+    width: 60px;
+    height: 70px;
+  }
+
+  dl {
+    display: flex;
+    gap: 20px;
+  }
+
+  dt {
+    font-weight: 700;
+  }
+`;
 
 export default OrderHistory;

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -19,28 +19,37 @@ const OrderHistory = () => {
       <ol>
         {history.map((list) => (
           <li key={list.detailId}>
-            <div>{list.timePaid}</div>
-            <ProductInfo>
-              <Link to={`/product/${list.product.productId}`}>
-                <img src={list.product.thumbnail} alt={`${list.product.title} 썸네일`} />
-              </Link>
-              <div>
-                <dl>
-                  <dt>상품명</dt>
-                  <dd>
-                    [{list.product.tags[0]}]{list.product.title}
-                  </dd>
-                </dl>
-                <dl>
-                  <dt>주문번호</dt>
-                  <dd>{list.detailId}</dd>
-                </dl>
-                <dl>
-                  <dt>결제금액</dt>
-                  <dd>${list.product.price.toLocaleString()}</dd>
-                </dl>
-              </div>
-            </ProductInfo>
+            <Title>
+              <h4>{list.timePaid}</h4>
+              <span>주문내역 상세보기 ></span>
+            </Title>
+            <Details>
+              <ProductInfo>
+                <Link to={`/product/${list.product.productId}`}>
+                  <img src={list.product.thumbnail} alt={`${list.product.title} 썸네일`} />
+                </Link>
+                <div>
+                  <dl>
+                    <dt>상품명</dt>
+                    <dd>
+                      [{list.product.tags[0]}]{list.product.title}
+                    </dd>
+                  </dl>
+                  <dl>
+                    <dt>주문번호</dt>
+                    <dd>{list.detailId}</dd>
+                  </dl>
+                  <dl>
+                    <dt>결제금액</dt>
+                    <dd>${list.product.price.toLocaleString()}</dd>
+                  </dl>
+                </div>
+              </ProductInfo>
+              <CancleOk>
+                <button>거래확정</button>
+                <button>취소</button>
+              </CancleOk>
+            </Details>
           </li>
         ))}
       </ol>
@@ -49,10 +58,22 @@ const OrderHistory = () => {
 };
 
 const Container = styled.div`
+  padding-top: 30px;
   li + li {
     margin-top: 30px;
-    border-top: 1px solid #000;
   }
+`;
+
+const Title = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #dfdfdf;
+`;
+
+const Details = styled.div`
+  display: flex;
+  justify-content: space-between;
 `;
 
 const ProductInfo = styled.div`
@@ -72,6 +93,19 @@ const ProductInfo = styled.div`
 
   dt {
     font-weight: 700;
+  }
+`;
+
+const CancleOk = styled.div`
+  display: flex;
+  gap: 20px;
+  align-items: center;
+  button {
+    padding: 0 30px;
+    height: 40px;
+    border: 1px solid #000;
+    border-radius: 5px;
+    cursor: pointer;
   }
 `;
 

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import reset from '../../css/reset-css.css';
 import styled from 'styled-components';
 import { transaction } from '../../utils/useAPI';
@@ -20,7 +21,9 @@ const OrderHistory = () => {
           <li key={list.detailId}>
             <div>{list.timePaid}</div>
             <ProductInfo>
-              <img src={list.product.thumbnail} alt={`${list.product.title} 썸네일`} />
+              <Link to={`/product/${list.product.productId}`}>
+                <img src={list.product.thumbnail} alt={`${list.product.title} 썸네일`} />
+              </Link>
               <div>
                 <dl>
                   <dt>상품명</dt>

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -88,7 +88,7 @@ const OrderHistory = () => {
                 ) : list.done ? (
                   <>
                     <button type="button" className="confirmtrue">
-                      확정완료
+                      배송완료
                     </button>
                   </>
                 ) : list.isCanceled ? (
@@ -96,7 +96,6 @@ const OrderHistory = () => {
                     <button type="button" className="confirmtrue">
                       취소완료
                     </button>
-                    {console.log(ddEl)}
                   </>
                 ) : (
                   ''

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -2,31 +2,38 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import reset from '../../css/reset-css.css';
 import styled from 'styled-components';
-import { transaction } from '../../utils/useAPI';
+import { orderedProducts, confirmProduct } from '../../utils/useAPI';
 
 const OrderHistory = () => {
-  const [history, setHistory] = useState([]);
-  useEffect(() => {
-    const getTransaction = async () => {
-      const json = await transaction();
-      setHistory(json);
-    };
-    getTransaction();
-  }, []);
-  console.log(history);
+  const [ordered, setOdered] = useState([]);
+  const [confirmed, setConfirmed] = useState('');
 
-  const handleConfirm = (id) => {
-    // const confirm = async (id) => {
-    //   const json = await confirmProduct(id);
-    //   return json;
-    // };
-    // confirm();
+  useEffect(() => {
+    const getorderedProducts = async () => {
+      const json = await orderedProducts();
+      setOdered(json);
+    };
+    getorderedProducts();
+    console.log(ordered);
+  }, []);
+
+  const orderConfirm = async (detailId) => {
+    let body = JSON.stringify({
+      detailId: detailId,
+    });
+    const json = await confirmProduct(body);
+    setConfirmed(json);
   };
+
+  const handelOrderConfirm = (detailId) => {
+    orderConfirm(detailId);
+  };
+  //
 
   return (
     <Container>
       <ol>
-        {history.map((list) => (
+        {ordered.map((list) => (
           <li key={list.detailId}>
             <Title>
               <h4>{list.timePaid}</h4>
@@ -55,8 +62,17 @@ const OrderHistory = () => {
                 </div>
               </ProductInfo>
               <CancleOk>
-                <button onClick={handleConfirm(list.detailId)}>거래확정</button>
-                <button>취소</button>
+                {list.done ? (
+                  <button type="button" className="confirmtrue">
+                    확정완료
+                  </button>
+                ) : (
+                  <button type="button" onClick={() => handelOrderConfirm(list.detailId)}>
+                    거래 확정
+                  </button>
+                )}
+
+                <button>거래 취소</button>
               </CancleOk>
             </Details>
           </li>
@@ -109,12 +125,17 @@ const CancleOk = styled.div`
   display: flex;
   gap: 20px;
   align-items: center;
+
   button {
     padding: 0 30px;
     height: 40px;
-    border: 1px solid #000;
+    border: 1px solid #dfdfdf;
     border-radius: 5px;
     cursor: pointer;
+  }
+
+  .confirmtrue {
+    background-color: #eaeaea;
   }
 `;
 

--- a/src/components/Userpage/OrderHistory.js
+++ b/src/components/Userpage/OrderHistory.js
@@ -14,6 +14,15 @@ const OrderHistory = () => {
     getTransaction();
   }, []);
   console.log(history);
+
+  const handleConfirm = (id) => {
+    // const confirm = async (id) => {
+    //   const json = await confirmProduct(id);
+    //   return json;
+    // };
+    // confirm();
+  };
+
   return (
     <Container>
       <ol>
@@ -46,7 +55,7 @@ const OrderHistory = () => {
                 </div>
               </ProductInfo>
               <CancleOk>
-                <button>거래확정</button>
+                <button onClick={handleConfirm(list.detailId)}>거래확정</button>
                 <button>취소</button>
               </CancleOk>
             </Details>

--- a/src/components/Userpage/OrderHistoryDetails.js
+++ b/src/components/Userpage/OrderHistoryDetails.js
@@ -1,0 +1,26 @@
+import React, { useEffect, useState } from 'react';
+import reset from '../../css/reset-css.css';
+import styled from 'styled-components';
+import { transactionDetails } from '../../utils/useAPI';
+
+const OrderHistory = () => {
+  const [list, setList] = useState();
+  useEffect(() => {
+    const getTransaction = async () => {
+      const json = await transactionDetails();
+      setList(json);
+    };
+    getTransaction();
+  }, []);
+  console.log(list);
+  return (
+    <Container>
+      나의 주문내역 컴포넌트
+      <div>{list}</div>
+    </Container>
+  );
+};
+
+const Container = styled.div``;
+
+export default OrderHistory;

--- a/src/pages/CartPage.js
+++ b/src/pages/CartPage.js
@@ -6,6 +6,7 @@ import { auth } from '../utils/useAPI';
 import Header from '../components/Header';
 import Navbar from '../components/Navbar';
 import Step from '../components/Step';
+import Footer from '../components/Footer';
 
 const CartPage = () => {
   /////////////// 세션 스토리지 조회 ///////////////
@@ -170,6 +171,7 @@ const CartPage = () => {
           </Wrap>
         )}
       </Container>
+      <Footer />
     </div>
   );
 };

--- a/src/pages/CartPage.js
+++ b/src/pages/CartPage.js
@@ -88,7 +88,9 @@ const CartPage = () => {
               <ProductsTable>
                 {cart.map((cart) => (
                   <CartList key={cart.id} id={cart.id}>
-                    <img src={cart.thumbnail} alt="상세이미지" />
+                    <Link to={`/product/${cart.id}`}>
+                      <img src={cart.thumbnail} alt="상세이미지" />
+                    </Link>
                     <Info>
                       <p>{cart.title}</p>
                       <span>${cart.price.toLocaleString()}</span>

--- a/src/pages/CartPage.js
+++ b/src/pages/CartPage.js
@@ -44,6 +44,7 @@ const CartPage = () => {
   const onChangeQuantity = (id, value, key = 'quantity') => {
     const product = cart.filter((element) => element.id === id);
     product[0].quantity = value;
+    setCart(cart);
     setSsesionData('cart', cart);
   };
 
@@ -104,7 +105,7 @@ const CartPage = () => {
                         十
                       </button>
                     </Quantity>
-                    <span>${(cart.price * cart.quantity).toLocaleString()}</span>
+                    <Calculated>${(cart.price * cart.quantity).toLocaleString()}</Calculated>
                     <button className="deleteBtn" onClick={(event) => handleDeleteCart(event)}>
                       ✕
                     </button>
@@ -242,6 +243,11 @@ const Quantity = styled.div`
   .btn-disabled {
     color: #dfdfdf;
   }
+`;
+
+const Calculated = styled.div`
+  width: 60px;
+  text-align: center;
 `;
 
 //Order Summary 스타일

--- a/src/pages/CartPage.js
+++ b/src/pages/CartPage.js
@@ -91,7 +91,7 @@ const CartPage = () => {
                     <img src={cart.thumbnail} alt="상세이미지" />
                     <Info>
                       <p>{cart.title}</p>
-                      <span>${cart.price}</span>
+                      <span>${cart.price.toLocaleString()}</span>
                     </Info>
                     <Quantity>
                       <button type="button" onClick={handleQuantityDecrease}>
@@ -102,7 +102,7 @@ const CartPage = () => {
                         十
                       </button>
                     </Quantity>
-                    <span>${cart.price * cart.quantity}</span>
+                    <span>${(cart.price * cart.quantity).toLocaleString()}</span>
                     <button className="deleteBtn" onClick={(event) => handleDeleteCart(event)}>
                       ✕
                     </button>
@@ -115,7 +115,7 @@ const CartPage = () => {
               <Price>
                 <li>
                   <span>Subtotal</span>
-                  <span>${totalPrice}</span>
+                  <span>${totalPrice.toLocaleString()}</span>
                 </li>
                 <li>
                   <span>Shipping </span>
@@ -124,7 +124,7 @@ const CartPage = () => {
               </Price>
               <Total>
                 <span>Total</span>
-                <span>${totalPrice}</span>
+                <span>${totalPrice.toLocaleString()}</span>
               </Total>
               <LinkWrap>
                 <Link to={'/order'}>

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -126,7 +126,7 @@ const ProductdetailsPage = () => {
             <li>
               <h2>{product.title}</h2>
             </li>
-            <li>${product.price.toLocaleString()}</li>
+            <li>${product.price}</li>
           </Info>
 
           <Tab>
@@ -196,14 +196,18 @@ const Sidebar = styled.aside`
   position: fixed;
   top: 190px;
   right: 0;
-  width: 400px;
+  width: 25%;
+  min-width: 300px;
   padding-right: 20px;
+
+  background-color: #fff;
 `;
 
 const Category = styled.ol`
   display: flex;
   gap: 10px;
   margin-bottom: 10px;
+
   color: rgb(137, 137, 137);
   font-size: 12px;
   li {

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -38,10 +38,7 @@ const ProductdetailsPage = () => {
   //confirm창(상품 담기 확인 및 장바구니 이동)
   const navigate = useNavigate();
   const moveTocart = () => {
-    if (
-      window.confirm(`상품을 장바구니에 담았습니다. 
-    장바구니로 이동하시겠습니까?`)
-    ) {
+    if (window.confirm(`상품을 장바구니에 담았습니다. \n장바구니로 이동하시겠습니까?`)) {
       navigate('/cart');
     }
   };

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -153,7 +153,7 @@ const ProductdetailsPage = () => {
 
           <Btns>
             {product.isSoldOut ? (
-              <button>SOLD OUT</button>
+              <button className="soldout">SOLD OUT</button>
             ) : (
               <div>
                 <Link to={'/order'}>
@@ -254,6 +254,10 @@ const Btns = styled.div`
     padding: 10px 0;
     border: 1px solid #000;
     cursor: pointer;
+  }
+
+  .soldout {
+    color: #a6a6a6;
   }
 `;
 

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { getProductDetail } from '../utils/useAPI';
 import Header from '../components/Header';
 import Navbar from '../components/Navbar';
+import Footer from '../components/Footer';
 
 const ProductdetailsPage = () => {
   /////////////// 단일 제품상세 불러오기 ///////////////
@@ -94,7 +95,7 @@ const ProductdetailsPage = () => {
     <div>
       <Header />
       <Navbar />
-      <Wrap>
+      <Container>
         <ImageWrap>
           <img src={product.thumbnail} alt={`${product.title} 썸네일`} />
           <img src={product.photo} alt={`${product.title} 상세이미지`} />
@@ -164,12 +165,13 @@ const ProductdetailsPage = () => {
             )}
           </Btns>
         </Sidebar>
-      </Wrap>
+      </Container>
+      <Footer />
     </div>
   );
 };
 
-const Wrap = styled.main`
+const Container = styled.main`
   padding: 100px 0;
 `;
 const ImageWrap = styled.div`

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -126,7 +126,7 @@ const ProductdetailsPage = () => {
             <li>
               <h2>{product.title}</h2>
             </li>
-            <li>${product.price}</li>
+            <li>${parseInt(product.price).toLocaleString()}</li>
           </Info>
 
           <Tab>

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -126,7 +126,7 @@ const ProductdetailsPage = () => {
             <li>
               <h2>{product.title}</h2>
             </li>
-            <li>${product.price}</li>
+            <li>${product.price.toLocaleString()}</li>
           </Info>
 
           <Tab>

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -84,6 +84,8 @@ const ProductdetailsPage = () => {
   };
 
   ////////// 결제 상품, 세션스토리지로 ////////
+  let order = [];
+  order.push(product);
   sessionStorage.setItem('order', JSON.stringify());
   const orderSsesionData = (orderProducts) => {
     sessionStorage.setItem('order', JSON.stringify(orderProducts));
@@ -134,7 +136,7 @@ const ProductdetailsPage = () => {
 
           <Btns>
             <Link to={'/order'}>
-              <button onClick={() => orderSsesionData(product)}>BUY NOW</button>
+              <button onClick={() => orderSsesionData(order)}>BUY NOW</button>
             </Link>
             <button onClick={handleCart}>ADD TO CART</button>
           </Btns>

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -98,17 +98,28 @@ const ProductdetailsPage = () => {
       <Wrap>
         <ImageWrap>
           <img src={product.thumbnail} alt={`${product.title} 썸네일`} />
-          <div>
-            <h3>details</h3>
-          </div>
           <img src={product.photo} alt={`${product.title} 상세이미지`} />
         </ImageWrap>
 
         <Sidebar>
           <Category>
-            <li>Shop</li>
-            <li>{copyTags[1]}</li>
-            <li>{copyTags[0]}</li>
+            <li>
+              <Link to={'/category/all'}>Category</Link>
+            </li>
+            <li>
+              {copyTags[1] === '가방' ? (
+                <Link to={'/category/bags'}>{copyTags[1]}</Link>
+              ) : (
+                <Link to={'/category/clothes'}>{copyTags[1]}</Link>
+              )}
+            </li>
+            <li>
+              {copyTags[0] === 'LOUIS VUITTON' ? (
+                <Link to={`/category/all/LOUIS`}>{copyTags[0]}</Link>
+              ) : (
+                <Link to={`/category/all/${copyTags[0]}`}>{copyTags[0]}</Link>
+              )}
+            </li>
           </Category>
 
           <Info>

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -88,6 +88,8 @@ const ProductdetailsPage = () => {
     sessionStorage.setItem('order', JSON.stringify(orderProducts));
   };
 
+  ////////// 매진 여부에 따른 출력 변경 ////////
+  console.log(product);
   return (
     <div>
       <Header />
@@ -150,10 +152,16 @@ const ProductdetailsPage = () => {
           </Tab>
 
           <Btns>
-            <Link to={'/order'}>
-              <button onClick={() => orderSsesionData(order)}>BUY NOW</button>
-            </Link>
-            <button onClick={handleCart}>ADD TO CART</button>
+            {product.isSoldOut ? (
+              <button>SOLD OUT</button>
+            ) : (
+              <div>
+                <Link to={'/order'}>
+                  <button onClick={() => orderSsesionData(order)}>BUY NOW</button>
+                </Link>
+                <button onClick={handleCart}>ADD TO CART</button>
+              </div>
+            )}
           </Btns>
         </Sidebar>
       </Wrap>
@@ -240,11 +248,9 @@ const Tab = styled.dl`
 `;
 
 const Btns = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
   button {
     width: 100%;
+    margin-top: 10px;
     padding: 10px 0;
     border: 1px solid #000;
     cursor: pointer;

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -196,8 +196,7 @@ const Sidebar = styled.aside`
   position: fixed;
   top: 190px;
   right: 0;
-  width: 25%;
-  min-width: 300px;
+  width: 400px;
   padding-right: 20px;
 
   background-color: #fff;

--- a/src/pages/ProductdetailsPage.js
+++ b/src/pages/ProductdetailsPage.js
@@ -97,17 +97,24 @@ const ProductdetailsPage = () => {
       <Navbar />
       <Wrap>
         <ImageWrap>
+          <img src={product.thumbnail} alt={`${product.title} 썸네일`} />
+          <div>
+            <h3>details</h3>
+          </div>
           <img src={product.photo} alt={`${product.title} 상세이미지`} />
         </ImageWrap>
 
         <Sidebar>
           <Category>
-            <li>{copyTags[0]}</li>
+            <li>Shop</li>
             <li>{copyTags[1]}</li>
+            <li>{copyTags[0]}</li>
           </Category>
 
           <Info>
-            <li>{product.title}</li>
+            <li>
+              <h2>{product.title}</h2>
+            </li>
             <li>${product.price}</li>
           </Info>
 
@@ -151,9 +158,25 @@ const Wrap = styled.main`
 `;
 const ImageWrap = styled.div`
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  align-items: center;
   img {
     width: 500px;
+  }
+
+  img:first-child {
+    margin-bottom: 150px;
+    border: 1px solid #000;
+  }
+
+  img:last-child {
+    padding-top: 50px;
+    border-top: 1px solid #000;
+  }
+
+  h3 {
+    padding-bottom: 20px;
+    text-align: left;
   }
 `;
 const Sidebar = styled.aside`

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -45,21 +45,21 @@ const UserPage = () => {
               {array
                 .filter((item) => item.id !== 'Auth')
                 .map((item) => (
-                  <>
+                  <div key={item.id}>
                     {item.id === 'Account' ? (
                       <Link to={`/user/Auth`}>
-                        <li key={item.id}>
+                        <li>
                           <button>{item.title}</button>
                         </li>
                       </Link>
                     ) : (
                       <Link to={`/user/${item.id}`}>
-                        <li key={item.id}>
+                        <li>
                           <button>{item.title}</button>
                         </li>
                       </Link>
                     )}
-                  </>
+                  </div>
                 ))}
             </ul>
           </Menu>
@@ -119,12 +119,6 @@ const Menu = styled.nav`
   flex-direction: column;
   gap: 30px;
   min-width: 250px;
-
-  div {
-    padding: 45px 0;
-    font-weight: 700;
-    font-size: 40px;
-  }
 
   ul li {
     margin-top: 5px;

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { auth } from '../utils/useAPI';
 import Header from '../components/Header';
@@ -7,7 +8,7 @@ import OrderHistory from '../components/Userpage/OrderHistory';
 import CancleHistory from '../components/Userpage/CancleHistory';
 import Account from '../components/Userpage/Account';
 import EditMemberInfo from '../components/Userpage/EditMemberInfo';
-import InputPassword from '../components/Userpage/InputPassword';
+import AuthPassword from '../components/Userpage/AuthPassword';
 import Footer from '../components/Footer';
 
 const UserPage = () => {
@@ -24,10 +25,11 @@ const UserPage = () => {
 
   //내비게이션 탭별 화면 전환
   const array = [
-    { id: 0, title: '나의 주문내역', description: <OrderHistory /> },
-    { id: 1, title: '취소 내역', description: <CancleHistory /> },
-    { id: 2, title: '내 계좌', description: <InputPassword user={user} /> },
-    { id: 3, title: '내정보 수정', description: <InputPassword user={user} /> },
+    { id: 'orderHistory', title: '나의 주문내역', description: <OrderHistory /> },
+    { id: 'cancleHistory', title: '취소 내역', description: <CancleHistory /> },
+    { id: 'account', title: '내 계좌', description: <Account user={user} /> },
+    { id: 'editMemberInfo', title: '내정보 수정', description: <EditMemberInfo user={user} /> },
+    { id: 'auth', title: '비밀번호 확인', description: <AuthPassword user={user} /> },
   ];
   const [title, setTitle] = useState('나의 주문내역');
 
@@ -41,9 +43,11 @@ const UserPage = () => {
             <div>{user.displayName}님</div>
             <ul>
               {array.map((item) => (
-                <li key={item.id} onClick={() => setTitle(item.title)}>
-                  <button>{item.title}</button>
-                </li>
+                <Link to={`/user/${item.id}`}>
+                  <li key={item.id} onClick={() => setTitle(item.title)}>
+                    <button>{item.title}</button>
+                  </li>
+                </Link>
               ))}
             </ul>
           </Menu>
@@ -111,13 +115,10 @@ const Menu = styled.nav`
   }
 
   ul li {
+    margin-top: 5px;
     padding: 15px 10px;
     border: 1px solid #000;
     cursor: pointer;
-  }
-
-  ul li + li {
-    margin-top: 5px;
   }
 
   ul li button {

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -7,6 +7,7 @@ import OrderHistory from '../components/Userpage/OrderHistory';
 import CancleHistory from '../components/Userpage/CancleHistory';
 import Account from '../components/Userpage/Account';
 import EditMemberInfo from '../components/Userpage/EditMemberInfo';
+import InputPassword from '../components/Userpage/InputPassword';
 
 const UserPage = () => {
   //유저 정보
@@ -18,15 +19,16 @@ const UserPage = () => {
     };
     authUser();
   }, []);
+  console.log(user);
 
   //내비게이션 탭별 화면 전환
   const array = [
     { id: 0, title: '나의 주문내역', description: <OrderHistory /> },
     { id: 1, title: '취소 내역', description: <CancleHistory /> },
-    { id: 2, title: '내 계좌', description: <Account /> },
-    { id: 3, title: '내정보 수정', description: <EditMemberInfo /> },
+    { id: 2, title: '내 계좌', description: <InputPassword user={user} /> },
+    { id: 3, title: '내정보 수정', description: <InputPassword user={user} /> },
   ];
-  const [title, setTitle] = useState(0);
+  const [title, setTitle] = useState('나의 주문내역');
 
   return (
     <Container>
@@ -37,7 +39,7 @@ const UserPage = () => {
           <div>{user.displayName}님</div>
           <ul>
             {array.map((item) => (
-              <li key={item.id} onClick={() => setTitle(item.id)}>
+              <li key={item.id} onClick={() => setTitle(item.title)}>
                 <button>{item.title}</button>
               </li>
             ))}
@@ -59,14 +61,14 @@ const UserPage = () => {
           <Details>
             <Title>
               {array
-                .filter((item) => title === item.id)
+                .filter((item) => title === item.title)
                 .map((item) => (
                   <div key={item.id}>{item.title}</div>
                 ))}
             </Title>
             <div>
               {array
-                .filter((item) => title === item.id)
+                .filter((item) => title === item.title)
                 .map((item) => (
                   <div key={item.id}>{item.description}</div>
                 ))}
@@ -155,7 +157,7 @@ const UserInfo = styled.div`
 const Details = styled.div`
   margin-top: 40px;
 `;
-const Title = styled.div`
+const Title = styled.h2`
   padding-bottom: 10px;
   border-bottom: 4px solid #000;
   font-size: 25px;

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -8,6 +8,7 @@ import CancleHistory from '../components/Userpage/CancleHistory';
 import Account from '../components/Userpage/Account';
 import EditMemberInfo from '../components/Userpage/EditMemberInfo';
 import InputPassword from '../components/Userpage/InputPassword';
+import Footer from '../components/Footer';
 
 const UserPage = () => {
   //유저 정보
@@ -31,52 +32,55 @@ const UserPage = () => {
   const [title, setTitle] = useState('나의 주문내역');
 
   return (
-    <Container>
+    <div>
       <Header />
       <Navbar />
-      <Main>
-        <Menu>
-          <div>{user.displayName}님</div>
-          <ul>
-            {array.map((item) => (
-              <li key={item.id} onClick={() => setTitle(item.title)}>
-                <button>{item.title}</button>
-              </li>
-            ))}
-          </ul>
-        </Menu>
-        <Transactions>
-          <UserInfo>
-            <div>
-              회원등급<span>ORANGE</span>
-              <button>할인혜택 보기</button>
-            </div>
-            <div>
-              사용가능한 계좌 잔액<span>000,000원</span>
-            </div>
-            <div>
-              배송중<span>0개</span>
-            </div>
-          </UserInfo>
-          <Details>
-            <Title>
-              {array
-                .filter((item) => title === item.title)
-                .map((item) => (
-                  <div key={item.id}>{item.title}</div>
-                ))}
-            </Title>
-            <div>
-              {array
-                .filter((item) => title === item.title)
-                .map((item) => (
-                  <div key={item.id}>{item.description}</div>
-                ))}
-            </div>
-          </Details>
-        </Transactions>
-      </Main>
-    </Container>
+      <Container>
+        <Main>
+          <Menu>
+            <div>{user.displayName}님</div>
+            <ul>
+              {array.map((item) => (
+                <li key={item.id} onClick={() => setTitle(item.title)}>
+                  <button>{item.title}</button>
+                </li>
+              ))}
+            </ul>
+          </Menu>
+          <Transactions>
+            <UserInfo>
+              <div>
+                회원등급<span>ORANGE</span>
+                <button>할인혜택 보기</button>
+              </div>
+              <div>
+                사용가능한 계좌 잔액<span>000,000원</span>
+              </div>
+              <div>
+                배송중<span>0개</span>
+              </div>
+            </UserInfo>
+            <Details>
+              <Title>
+                {array
+                  .filter((item) => title === item.title)
+                  .map((item) => (
+                    <div key={item.id}>{item.title}</div>
+                  ))}
+              </Title>
+              <div>
+                {array
+                  .filter((item) => title === item.title)
+                  .map((item) => (
+                    <div key={item.id}>{item.description}</div>
+                  ))}
+              </div>
+            </Details>
+          </Transactions>
+        </Main>
+      </Container>
+      <Footer />
+    </div>
   );
 };
 

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { auth } from '../utils/useAPI';
 import Header from '../components/Header';
@@ -25,12 +25,14 @@ const UserPage = () => {
 
   //내비게이션 탭별 화면 전환
   const array = [
-    { id: 'orderHistory', title: '나의 주문내역', description: <OrderHistory /> },
-    { id: 'cancleHistory', title: '취소 내역', description: <CancleHistory /> },
-    { id: 'account', title: '내 계좌', description: <Account user={user} /> },
-    { id: 'editMemberInfo', title: '내정보 수정', description: <EditMemberInfo user={user} /> },
-    { id: 'auth', title: '비밀번호 확인', description: <AuthPassword user={user} /> },
+    { id: 'OrderHistory', title: '나의 주문내역', description: <OrderHistory /> },
+    { id: 'CancleHistory', title: '취소 내역', description: <CancleHistory /> },
+    { id: 'Account', title: '내 계좌', description: <Account user={user} /> },
+    { id: 'EditMemberInfo', title: '내정보 수정', description: <EditMemberInfo user={user} /> },
+    { id: 'Auth', title: '비밀번호 재확인', description: <AuthPassword user={user} /> },
   ];
+
+  const { menu } = useParams();
   const [title, setTitle] = useState('나의 주문내역');
 
   return (
@@ -43,11 +45,7 @@ const UserPage = () => {
             <div>{user.displayName}님</div>
             <ul>
               {array.map((item) => (
-                <Link to={`/user/${item.id}`}>
-                  <li key={item.id} onClick={() => setTitle(item.title)}>
-                    <button>{item.title}</button>
-                  </li>
-                </Link>
+                {(item.id) === 'Account' ? console.log('비밀번호 재확인 페이지로 이동') : ''}
               ))}
             </ul>
           </Menu>
@@ -67,14 +65,15 @@ const UserPage = () => {
             <Details>
               <Title>
                 {array
-                  .filter((item) => title === item.title)
+                  .filter((item) => menu === item.id)
                   .map((item) => (
                     <div key={item.id}>{item.title}</div>
                   ))}
               </Title>
               <div>
+                {console.log(menu)}
                 {array
-                  .filter((item) => title === item.title)
+                  .filter((item) => menu === item.id)
                   .map((item) => (
                     <div key={item.id}>{item.description}</div>
                   ))}

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -42,23 +42,25 @@ const UserPage = () => {
           <Menu>
             <div>{user.displayName}님</div>
             <ul>
-              {array.map((item) => (
-                <>
-                  {item.id === 'Account' || item.id === 'EditMemberInfo' ? (
-                    <Link to={`/user/Auth`}>
-                      <li key={item.id}>
-                        <button>{item.title}</button>
-                      </li>
-                    </Link>
-                  ) : (
-                    <Link to={`/user/${item.id}`}>
-                      <li key={item.id}>
-                        <button>{item.title}</button>
-                      </li>
-                    </Link>
-                  )}
-                </>
-              ))}
+              {array
+                .filter((item) => item.id !== 'Auth')
+                .map((item) => (
+                  <>
+                    {item.id === 'Account' ? (
+                      <Link to={`/user/Auth`}>
+                        <li key={item.id}>
+                          <button>{item.title}</button>
+                        </li>
+                      </Link>
+                    ) : (
+                      <Link to={`/user/${item.id}`}>
+                        <li key={item.id}>
+                          <button>{item.title}</button>
+                        </li>
+                      </Link>
+                    )}
+                  </>
+                ))}
             </ul>
           </Menu>
           <Transactions>

--- a/src/pages/UserPage.js
+++ b/src/pages/UserPage.js
@@ -21,7 +21,6 @@ const UserPage = () => {
     };
     authUser();
   }, []);
-  console.log(user);
 
   //내비게이션 탭별 화면 전환
   const array = [
@@ -33,7 +32,6 @@ const UserPage = () => {
   ];
 
   const { menu } = useParams();
-  const [title, setTitle] = useState('나의 주문내역');
 
   return (
     <div>
@@ -45,7 +43,21 @@ const UserPage = () => {
             <div>{user.displayName}님</div>
             <ul>
               {array.map((item) => (
-                {(item.id) === 'Account' ? console.log('비밀번호 재확인 페이지로 이동') : ''}
+                <>
+                  {item.id === 'Account' || item.id === 'EditMemberInfo' ? (
+                    <Link to={`/user/Auth`}>
+                      <li key={item.id}>
+                        <button>{item.title}</button>
+                      </li>
+                    </Link>
+                  ) : (
+                    <Link to={`/user/${item.id}`}>
+                      <li key={item.id}>
+                        <button>{item.title}</button>
+                      </li>
+                    </Link>
+                  )}
+                </>
               ))}
             </ul>
           </Menu>
@@ -71,7 +83,6 @@ const UserPage = () => {
                   ))}
               </Title>
               <div>
-                {console.log(menu)}
                 {array
                   .filter((item) => menu === item.id)
                   .map((item) => (

--- a/src/utils/useAPI.js
+++ b/src/utils/useAPI.js
@@ -1,6 +1,8 @@
 import axios from '../api/axios';
 
-//로그인
+////////////////////// 인증 //////////////////////
+
+// 로그인
 export const signIn = async (value) => {
   try {
     const { email, password } = value;
@@ -34,6 +36,8 @@ export const auth = async (type = 'me') => {
   }
 };
 
+////////////////////// 계좌 //////////////////////
+
 // 계좌 관련 조회
 export const getAccount = async (type = '') => {
   // type: banks => 선택 가능한 은행 목록 조회, 기본: 계좌 목록 및 잔액 조회
@@ -51,20 +55,39 @@ export const getAccount = async (type = '') => {
   }
 };
 
-// 제품 조회
-export const getAllProduct = async (key) => {
+// 계좌 추가
+export const accountAdd = async (body = '') => {
   try {
-    if (key) {
-      axios.defaults.headers.common['masterKey'] = true;
-      const { data } = await axios.get(`/products`);
+    const token = localStorage.getItem('accessToken');
+    if (token !== null) {
+      axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+      const { data } = await axios.post(`/account`, body);
       console.log(data);
       return data;
     }
-    return false;
   } catch (err) {
-    console.log(err);
+    return err.response.data + '';
   }
 };
+
+// 계좌 해제
+export const delAccount = async (body = '') => {
+  try {
+    const token = localStorage.getItem('accessToken');
+    if (token !== null) {
+      axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+      const { data } = await axios.delete(`/account`, {
+        data: body,
+      });
+      console.log(data);
+      return data;
+    }
+  } catch (err) {
+    return err.response.data + '';
+  }
+};
+
+////////////////////// 제품 (관리자) //////////////////////
 
 // 제품 추가
 export const addProduct = async (key, list) => {
@@ -97,6 +120,22 @@ export const deleteProduct = async (key, id) => {
   }
 };
 
+////////////////////// 제품 (사용자) //////////////////////
+
+// 제품 조회
+export const getAllProduct = async (key) => {
+  try {
+    if (key) {
+      axios.defaults.headers.common['masterKey'] = true;
+      const { data } = await axios.get(`/products`);
+      console.log(data);
+      return data;
+    }
+    return false;
+  } catch (err) {
+    console.log(err);
+  }
+};
 // 제품 상세 조회
 export const getProductDetail = async (id) => {
   try {
@@ -109,22 +148,7 @@ export const getProductDetail = async (id) => {
   }
 };
 
-// 계좌 추가
-export const accountAdd = async (body = '') => {
-  try {
-    const token = localStorage.getItem('accessToken');
-    if (token !== null) {
-      axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
-      const { data } = await axios.post(`/account`, body);
-      console.log(data)
-      return data
-    }
-  }catch(err) {
-    return err.response.data + ''
-  }  
-};
-
-// 제품 구매
+// 제품 구매 신청
 export const buyProduct = async (body = '') => {
   try {
     const token = localStorage.getItem('accessToken');
@@ -135,23 +159,66 @@ export const buyProduct = async (body = '') => {
     }
     return false;
   } catch (err) {
-    return err.response.data + ''
+    return err.response.data + '';
   }
 };
 
-// 계좌 해제
-export const delAccount = async (body = '') => {
+// 제품 거래(구매) 취소
+// export const refundProduct = async (body = '') => {
+//   try {
+//     const token = localStorage.getItem('accessToken');
+//     if (token !== null) {
+//       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+//       const { data } = await axios.post(`/products/cancel`, body);
+//       console.log(data);
+//     }
+//     return false;
+//   } catch (err) {
+//     return err.response.data + '';
+//   }
+// };
+
+// 제품 거래(구매) 확정
+// export const confirmProduct = async (body = '') => {
+//   try {
+//     const token = localStorage.getItem('accessToken');
+//     if (token !== null) {
+//       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+//       const { data } = await axios.post(`/products/ok`, body);
+//       console.log(data);
+//     }
+//     return false;
+//   } catch (err) {
+//     return err.response.data + '';
+//   }
+// };
+
+// 전체 제품 거래(구매) 내역
+export const transaction = async () => {
   try {
     const token = localStorage.getItem('accessToken');
     if (token !== null) {
       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
-      const { data } = await axios.delete(`/account`, {
-        data: body,
-      });
+      const { data } = await axios.get(`/products/transactions/details`);
       console.log(data);
       return data;
     }
-  } catch(err) {
-    return err.response.data + ''
-  }  
+  } catch (err) {
+    return err.response.data + '';
+  }
 };
+
+// 단일 제품 상세 거래(구매) 내역
+// export const transactionDetails = async (body = '') => {
+//   try {
+//     const token = localStorage.getItem('accessToken');
+//     if (token !== null) {
+//       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+//       const { data } = await axios.get(`/products/transactions/detail`, body);
+//       console.log(data);
+//       return data;
+//     }
+//   } catch (err) {
+//     return err.response.data + '';
+//   }
+// };

--- a/src/utils/useAPI.js
+++ b/src/utils/useAPI.js
@@ -179,22 +179,22 @@ export const buyProduct = async (body = '') => {
 // };
 
 // 제품 거래(구매) 확정
-// export const confirmProduct = async (body = '') => {
-//   try {
-//     const token = localStorage.getItem('accessToken');
-//     if (token !== null) {
-//       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
-//       const { data } = await axios.post(`/products/ok`, body);
-//       console.log(data);
-//     }
-//     return false;
-//   } catch (err) {
-//     return err.response.data + '';
-//   }
-// };
+export const confirmProduct = async (body = '') => {
+  try {
+    const token = localStorage.getItem('accessToken');
+    if (token !== null) {
+      axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+      const { data } = await axios.post(`/products/ok`, body);
+      console.log(data);
+    }
+    return false;
+  } catch (err) {
+    return err.response.data + '';
+  }
+};
 
 // 전체 제품 거래(구매) 내역
-export const transaction = async () => {
+export const orderedProducts = async () => {
   try {
     const token = localStorage.getItem('accessToken');
     if (token !== null) {
@@ -209,7 +209,7 @@ export const transaction = async () => {
 };
 
 // 단일 제품 상세 거래(구매) 내역
-// export const transactionDetails = async (body = '') => {
+// export const orderedProduct = async (body = '') => {
 //   try {
 //     const token = localStorage.getItem('accessToken');
 //     if (token !== null) {

--- a/src/utils/useAPI.js
+++ b/src/utils/useAPI.js
@@ -164,19 +164,19 @@ export const buyProduct = async (body = '') => {
 };
 
 // 제품 거래(구매) 취소
-// export const refundProduct = async (body = '') => {
-//   try {
-//     const token = localStorage.getItem('accessToken');
-//     if (token !== null) {
-//       axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
-//       const { data } = await axios.post(`/products/cancel`, body);
-//       console.log(data);
-//     }
-//     return false;
-//   } catch (err) {
-//     return err.response.data + '';
-//   }
-// };
+export const refundProduct = async (body = '') => {
+  try {
+    const token = localStorage.getItem('accessToken');
+    if (token !== null) {
+      axios.defaults.headers.common['authorization'] = `Bearer ${token}`;
+      const { data } = await axios.post(`/products/cancel`, body);
+      console.log(data);
+    }
+    return false;
+  } catch (err) {
+    return err.response.data + '';
+  }
+};
 
 // 제품 거래(구매) 확정
 export const confirmProduct = async (body = '') => {

--- a/src/utils/useAPI.js
+++ b/src/utils/useAPI.js
@@ -148,6 +148,20 @@ export const getProductDetail = async (id) => {
   }
 };
 
+// 제품 검색
+export const searchProduct = async (searchText = '', searchTags = []) => {
+  try {
+    const { data } = await axios.post(`/products/search`, {
+      searchText,
+      searchTags,
+    });
+    console.log(data);
+    return data;
+  } catch (err) {
+    return console.log(err.message);
+  }
+};
+
 // 제품 구매 신청
 export const buyProduct = async (body = '') => {
   try {


### PR DESCRIPTION
👕개요
제품상세, 장바구니, 마이페이지 홈/주문내역/취소내역 수정

#👕작업사항

💼담당 구역 작업
*모두 동일하게 작업*
footer 추가
price 천단위마다 comma
useAPIs : 거래 취소, 거래 확정, 전체거래내역 API 추가

[제품 상세 페이지]
사이드바 배경색 흰색으로 처리
매진상품일 때, 결제/장바구니 버튼 숨기기

[장바구니 페이지]
썸네일 렌더
썸네일 클릭시 상세페이지로 이동
비회원일 때 주문하기 클릭시, 로그인 페이지로 이동

[마이페이지 홈]
마이페이지 내의 컴포넌트 별로 라우팅 작업
내계좌 탭버튼 클릭시, 비밀번호 재확인 창 나옴
비밀번호 재확인 창에서 올바르게 입력해야 내계좌로 이동

[마이페이지 주문내역]
주문내역 렌더
썸네일 누르면 상품 상세페이지로 이동
거래 확정, 취소 버튼 동작

[마이페이지 취소내역]
취소한 내역만 렌더

💼기존 구조에서 변경되거나 추가한 것
[components/Userpage]
* AuthPassword.js 파일 생성